### PR TITLE
Porting TQL to scalameta 0-1-0-SNAPSHOT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+.classpath
+.idea/
+.project
+*.iml
+*.swp
+*.swo
+project/
+target/
+*/target/

--- a/examples/src/main/scala/Example.scala
+++ b/examples/src/main/scala/Example.scala
@@ -14,7 +14,8 @@ import scala.meta.dialects.Scala211
 object Example extends App {
 
 
-  val x =
+  val x = {
+    import scala.meta._
     q"""
        val a = 5
        val c = 3
@@ -28,8 +29,10 @@ object Example extends App {
        else 2
        5
        """
+  }
 
-  val tree =
+  val tree = {
+    import scala.meta._
     q"""
        val a = 5
        val c = 3
@@ -40,6 +43,7 @@ object Example extends App {
        else 2
        5
        """
+  }
 
   val getAllVals = (collect[Set]{case x: Defn.Val => x.pats.head.toString}).topDown
 

--- a/examples/src/main/scala/FusionExample.scala
+++ b/examples/src/main/scala/FusionExample.scala
@@ -13,7 +13,8 @@ import scala.meta.dialects.Scala211
 
 object FusionExample extends App{
 
-  val x =
+  val x = {
+    import scala.meta._
     q"""
        val a = 1
        val c = 3
@@ -24,6 +25,7 @@ object FusionExample extends App{
        else 2
        5
     """
+  }
   var i = 0
   var j = 0
   var k = 0

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -6,7 +6,7 @@ object BuildSettings {
   lazy val metaVersion = "0.1.0-SNAPSHOT"
 
   val buildSettings = Seq(
-    version := "0.1.1-SNAPSHOT",
+    version := metaVersion,
     scalacOptions ++= Seq("-optimize", "-feature", /*"-Yinline-warnings",*/ "-deprecation"),
     //javaOptions := Seq("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5140"),
     scalaVersion := "2.11.5",

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -6,7 +6,7 @@ object BuildSettings {
   lazy val metaVersion = "0.1.0-SNAPSHOT"
 
   val buildSettings = Seq(
-    version := "0.1-SNAPSHOT",
+    version := "0.1.1-SNAPSHOT",
     scalacOptions ++= Seq("-optimize", "-feature", /*"-Yinline-warnings",*/ "-deprecation"),
     //javaOptions := Seq("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5140"),
     scalaVersion := "2.11.5",

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -3,7 +3,7 @@ import Keys._
 
 object BuildSettings {
 
-  lazy val metaVersion = "0.0.0-M0"
+  lazy val metaVersion = "0.1.0-SNAPSHOT"
 
   val buildSettings = Seq(
     version := "0.1-SNAPSHOT",

--- a/tql/src/main/scala/tql/TraverserHelper.scala
+++ b/tql/src/main/scala/tql/TraverserHelper.scala
@@ -49,6 +49,13 @@ object TraverserHelper {
     Some((if (hasChanged) collection.immutable.Seq(buffer: _*) else seq, acc))
   }
 
+  def traverseOptionalSeq[U, T <: U with AnyRef: ClassTag, A: Monoid](
+                       f: Traverser[U]#Matcher[A],
+                       a: Option[Seq[T]]): Option[(Option[Seq[T]], A)] = Some(
+    a.flatMap (traverseSeq(f, _))
+    .collect{case (x: Seq[T], y) => (Some(x), y)}
+    .getOrElse(None, implicitly[Monoid[A]].zero))
+
   def optional[U, T <: U with AnyRef : ClassTag, A: Monoid](
               f:  Traverser[U]#Matcher[A],
               a: Option[T]): Option[(Option[T], A)] = Some(a

--- a/tqlmacros/src/main/scala/TraverserHelperMacros.scala
+++ b/tqlmacros/src/main/scala/TraverserHelperMacros.scala
@@ -111,6 +111,8 @@ class TraverserBuilder(val c: Context) {
         Some(q"_root_.tql.TraverserHelper.traverseSeq($f, $name)")
       case t if t <:< weakTypeOf[scala.collection.immutable.Seq[scala.collection.immutable.Seq[T]]] =>
         Some(q"_root_.tql.TraverserHelper.traverseSeqofSeq($f, $name)")
+      case t if t <:< weakTypeOf[scala.Option[scala.collection.immutable.Seq[T]]] =>
+        Some(q"_root_.tql.TraverserHelper.traverseOptionalSeq($f, $name)")
       case t if t <:< weakTypeOf[scala.Option[T]] =>
         Some(q"_root_.tql.TraverserHelper.optional($f, $name)")
       case _ => None

--- a/tqlscalameta/src/main/scala/meta/tql/ScalaMetaFusionTraverser.scala
+++ b/tqlscalameta/src/main/scala/meta/tql/ScalaMetaFusionTraverser.scala
@@ -36,6 +36,6 @@ object ScalaMetaFusionTraverser extends Traverser[Tree]
       scala.meta.internal.ast.Term.ApplyInfix
     )
 
-  def TtoU(t: Tree): Int = t.$tag
+  def TtoU(t: Tree): Int = t.internalTag
   def optimize[A](m: Matcher[A]): Matcher[A] = macro ScalametaFusionTraverserHelperMacros.getAllTags
 }

--- a/tqlscalameta/src/main/scala/tools/ScalaToTree.scala
+++ b/tqlscalameta/src/main/scala/tools/ScalaToTree.scala
@@ -37,7 +37,7 @@ object ScalaToTree {
     /*Awesomely awful. If you know how to have early initialization with anonymous class please tell me
     * Please have mercy on me
     * */
-    def init: Unit ={
+    def init: Unit = {
       m_frontEnd = tb.getClass.getDeclaredMethod("frontEnd")
       frontEnd = m_frontEnd.invoke(tb).asInstanceOf[scala.tools.reflect.FrontEnd]
     }
@@ -88,7 +88,7 @@ object ScalaToTree {
     def scalaToMeta(tree: compiler.Tree) = {
       import scala.meta.internal.ast._
       implicit val c = Scalahost.mkSemanticContext[compiler.type](compiler)
-      c.toPtree(tree, classOf[Source])
+      c.toMtree(tree, classOf[Source])
     }
 
     def parseToMeta(code: String) = scalaToMeta(parseAndType(code))

--- a/tqlscalameta/src/main/scala/tools/ScalaToTree.scala
+++ b/tqlscalameta/src/main/scala/tools/ScalaToTree.scala
@@ -11,9 +11,11 @@ import scala.reflect.runtime.{universe => ru}
 import scala.tools.reflect.{ToolBox, ToolBoxError}
 import scala.compat.Platform.EOL
 import scala.meta.internal.hosts.scalac.Scalahost
+import scala.meta.internal.hosts.scalac._
+
 //import scala.meta.semantic.{Host => PalladiumHost}
 //import scala.meta.internal.hosts.scalac.{Host => OurHost}
-import scala.meta.internal.hosts.scalac.{Scalahost  => OurHost}
+//import scala.meta.internal.hosts.scalac.{Scalahost  => OurHost}
 
 /*
 * Lame attempt to make available the scala compiler to the user, to make use of scala and scala.meta Trees
@@ -86,7 +88,7 @@ object ScalaToTree {
     def scalaToMeta(tree: compiler.Tree) = {
       import scala.meta.internal.ast._
       implicit val c = Scalahost.mkSemanticContext[compiler.type](compiler)
-      c.toScalameta(tree, classOf[Source])
+      c.toPtree(tree, classOf[Source])
     }
 
     def parseToMeta(code: String) = scalaToMeta(parseAndType(code))

--- a/tqlscalameta/src/main/scala/tools/Traverser.scala
+++ b/tqlscalameta/src/main/scala/tools/Traverser.scala
@@ -17,7 +17,7 @@ class TraverserTableTag{
 
   val myTable = TraverserTableTag.buildTraverseTable
 
-  def traverse(tree: Tree): Unit = myTable(tree.$tag)(tree, traverse _)
+  def traverse(tree: Tree): Unit = myTable(tree.internalTag)(tree, traverse _)
 }
 
 object TraverserTableTag {

--- a/tqlscalameta/src/main/scala/tools/Traverser.scala
+++ b/tqlscalameta/src/main/scala/tools/Traverser.scala
@@ -24,7 +24,7 @@ object TraverserTableTag {
   def buildTraverseTable: Array[(Tree, Tree => Unit) => Unit] = TraverserBuilder.buildTraverseTable[Tree]
 }
 
-/*Change the order of the pattern mathc, as in the scalac traverser*/
+/*Change the order of the pattern mathch, as in the scalac traverser*/
 class Traverser extends TraverserTableTag {
   import scala.meta.internal.ast._
 

--- a/tqlscalameta/src/main/scala/tools/Traverser.scala
+++ b/tqlscalameta/src/main/scala/tools/Traverser.scala
@@ -52,10 +52,10 @@ class Traverser extends TraverserTableTag {
   override def traverse(tree: scala.meta.Tree) = tree match {
     case _: Term.Name | _ : Lit.Char | _ : Lit.Int | _ : Type.Name | _: Term.Param | _: Type.Apply =>
     case _ : Pat.Wildcard =>
-    case Case(pat, conds, stats) =>
+    case Case(pat, conds, block) =>
       traverse(pat)
       conds.foreach(traverseTerm(_))
-      stats.foreach(traverse(_))
+      block.stats.foreach(traverse(_))
     case Pat.Extract(ref, targs, elements) =>
       traverseTerm(ref)
       targs.foreach(traverse(_))

--- a/tqlscalameta/src/test/resources/Propaganda.scala
+++ b/tqlscalameta/src/test/resources/Propaganda.scala
@@ -20,6 +20,6 @@ object Propaganda {
     }
 
     var c = 3
-    val v = List(1,2,3).toSet()
+    val v = List(1,2,3).toSet(())
   }
 }

--- a/tqlscalameta/src/test/scala/meta/tql/ForbidVarsInMethodsSuite.scala
+++ b/tqlscalameta/src/test/scala/meta/tql/ForbidVarsInMethodsSuite.scala
@@ -20,7 +20,7 @@ class ForbidVarsInMethodsSuite extends FunSuite {
   //tql traverser
   val forbidVarsInMethods = {
     def checkMethod: Matcher[List[String]] =
-      focus{ case _: Defn.Procedure => true} feed { method =>
+      focus{ case _: Defn.Def => true} feed { method =>
 
         val warn = collect{
           case Defn.Var(_, (b: Term.Name):: Nil,_, _) =>
@@ -41,14 +41,14 @@ class ForbidVarsInMethodsSuite extends FunSuite {
     var currentMethod: Term.Name = null
     new Traverser {
       override def traverse(tree:  scala.meta.Tree): Unit = tree match {
-        case f: Defn.Procedure =>
+        case f: Defn.Def =>
           val oldFunc = currentMethod
           currentMethod = f.name
           super.traverse(tree)
           currentMethod = oldFunc
         case Defn.Var(_, (b: Term.Name):: Nil,_, _)
           if currentMethod != null =>
-          val newWarning = b + " should not be used in " + currentMethod.name
+          val newWarning = b + " should not be used in " + currentMethod.value
           warnings = newWarning :: warnings
           super.traverse(tree)
         case _ =>

--- a/tqlscalameta/src/test/scala/meta/tql/FusionBenchmarks.scala
+++ b/tqlscalameta/src/test/scala/meta/tql/FusionBenchmarks.scala
@@ -22,7 +22,9 @@ object FusionBenchmarks  extends PerformanceTest {
   val range = Gen.enumeration("size")(100)
 
   val compiler: CompilerProxy = ScalaToTree.loadCompiler
-  val scalaTree = compiler.parseAndType(ScalaToTree.loadSource(System.getProperty("user.dir") + "/tqlscalameta/src/test/resources/Huffman.scala"))
+  // TODO: change to use FusionBenchmarks.scala, but the file cannot be put in git. Using GenSeqLike.scala by default.
+  // val scalaTree = compiler.parseAndType(ScalaToTree.loadSource(System.getProperty("user.dir") + "/tqlscalameta/src/test/resources/FusionBenchmarks.scala"))
+  val scalaTree = compiler.parseAndType(ScalaToTree.loadSource(System.getProperty("user.dir") + "/tqlscalameta/src/test/resources/GenSeqLike.scala"))
 
   val scalaMetaTree:scala.meta.Tree = compiler.scalaToMeta(scalaTree)
 

--- a/tqlscalameta/src/test/scala/meta/tql/FusionSuite.scala
+++ b/tqlscalameta/src/test/scala/meta/tql/FusionSuite.scala
@@ -11,7 +11,10 @@ import scala.meta.internal.ast._
 class FusionSuite extends FunSuite {
 
   val compiler: CompilerProxy = ScalaToTree.loadCompiler
-  val scalaTree = compiler.parseAndType(ScalaToTree.loadSource(System.getProperty("user.dir") + "/tqlscalameta/src/test/resources/Huffman.scala"))
+
+  // TODO: change to use FusionBenchmarks.scala, but the file cannot be put in git. Using GenSeqLike.scala by default.
+  //val scalaTree = compiler.parseAndType(ScalaToTree.loadSource(System.getProperty("user.dir") + "/tqlscalameta/src/test/resources/Huffman.scala"))
+  val scalaTree = compiler.parseAndType(ScalaToTree.loadSource(System.getProperty("user.dir") + "/tqlscalameta/src/test/resources/GenSeqLike.scala"))
 
   val scalaMetaTree:scala.meta.Tree = compiler.scalaToMeta(scalaTree)
 

--- a/tqlscalameta/src/test/scala/meta/tql/ObeyRuleSuite.scala
+++ b/tqlscalameta/src/test/scala/meta/tql/ObeyRuleSuite.scala
@@ -21,19 +21,15 @@ class ObeyRuleSuite extends FunSuite {
 
   val propaganda = ScalaToTree.load(System.getProperty("user.dir") + "/tqlscalameta/src/test/resources/Propaganda.scala")
 
-
   //rule taken from the Obey project
   val listToSetBool = topDown(transform {
     case tt @ Term.Apply(t@Term.Select(Term.Apply(Term.Name("List"), _), Term.Name("toSet")), _) =>
       t andCollect tt.toString
   })
-
-
   test("listToSetBool") {
-      val res = listToSetBool(propaganda)
-      val newCode = res.tree.get
-      assert(newCode != propaganda)
+    val res = listToSetBool(propaganda)
+    val newCode = res.tree.get
+    assert(newCode != propaganda)
   }
-
-
+  
 }

--- a/tqlscalameta/src/test/scala/meta/tql/OptimizeBenchmarks.scala
+++ b/tqlscalameta/src/test/scala/meta/tql/OptimizeBenchmarks.scala
@@ -23,7 +23,9 @@ object OptimizeBenchmarks extends PerformanceTest{
   val range = Gen.enumeration("size")(100)
 
   val compiler: CompilerProxy = ScalaToTree.loadCompiler
-  val scalaTree = compiler.parseAndType(ScalaToTree.loadSource(System.getProperty("user.dir") + "/tqlscalameta/src/test/resources/Huffman.scala"))
+  // TODO: change to use FusionBenchmarks.scala, but the file cannot be put in git. Using GenSeqLike.scala by default.
+  // val scalaTree = compiler.parseAndType(ScalaToTree.loadSource(System.getProperty("user.dir") + "/tqlscalameta/src/test/resources/Huffman.scala"))
+  val scalaTree = compiler.parseAndType(ScalaToTree.loadSource(System.getProperty("user.dir") + "/tqlscalameta/src/test/resources/GenSeqLike.scala"))
 
   val scalaMetaTree:scala.meta.Tree = compiler.scalaToMeta(scalaTree)
 

--- a/tqlscalametamacros/src/main/scala/scala.meta.tql/AllowedTransformationsMacros.scala
+++ b/tqlscalametamacros/src/main/scala/scala.meta.tql/AllowedTransformationsMacros.scala
@@ -14,7 +14,7 @@ class AllowedTransformationsMaterializer(val c: Context) extends org.scalameta.a
   import c.universe._
 
   def materialize[T : c.WeakTypeTag, I : c.WeakTypeTag, O : c.WeakTypeTag]: c.Expr[tql.AllowedTransformation[I, O]] = {
-    val brlhs = getBranch[I].filterNot(_.sym.fullName == u.symbolOf[T].fullName)
+    val brlhs = getBranch[I].filterNot(_.fullName == u.symbolOf[T].fullName)
     val Tout = u.symbolOf[O].asType
     //c.abort(c.enclosingPosition, show(Tout) + " : " + show(brlhs.filter(x => Tout.toType <:< x.info.typeSymbol.asType.toType)))
 
@@ -25,9 +25,8 @@ class AllowedTransformationsMaterializer(val c: Context) extends org.scalameta.a
         "impossible to materialize AllowedTransformations[" +
           show(implicitly[c.WeakTypeTag[I]].tpe) + ", " +
           show(implicitly[c.WeakTypeTag[O]].tpe) + "]" + "\n" +
-          "because " + show(Tout.sym.fullName) + " is not a subtype of any in " + show(brlhs) + "\n")
+          "because " + show(Tout.fullName) + " is not a subtype of any in " + show(brlhs) + "\n")
   }
-
 
   private def getBranch[A : c.WeakTypeTag]: List[TypeSymbol] = {
     val Asym = u.symbolOf[A]

--- a/tqlscalametamacros/src/main/scala/scala.meta.tql/AllowedTransformationsMacros.scala
+++ b/tqlscalametamacros/src/main/scala/scala.meta.tql/AllowedTransformationsMacros.scala
@@ -11,7 +11,9 @@ import scala.reflect.macros.blackbox.Context
 
 class AllowedTransformationsMaterializer(val c: Context) extends org.scalameta.adt.AdtReflection{
   val u: c.universe.type = c.universe
+  val mirror: u.Mirror = c.mirror
   import c.universe._
+  val XtensionQuasiquoteTerm = "shadow scala.meta quasiquotes"
 
   def materialize[T : c.WeakTypeTag, I : c.WeakTypeTag, O : c.WeakTypeTag]: c.Expr[tql.AllowedTransformation[I, O]] = {
     val brlhs = getBranch[I].filterNot(_.fullName == u.symbolOf[T].fullName)

--- a/tqlscalametamacros/src/main/scala/scala.meta.tql/ScalametaFusionTraverserHelperMacros.scala
+++ b/tqlscalametamacros/src/main/scala/scala.meta.tql/ScalametaFusionTraverserHelperMacros.scala
@@ -13,7 +13,9 @@ class ScalametaFusionTraverserHelperMacros(override val c: Context)
   extends TraverserBuilder(c)
   with org.scalameta.adt.AdtReflection {
   val u: c.universe.type = c.universe
+  val mirror: u.Mirror = c.mirror
   import c.universe._
+  val XtensionQuasiquoteTerm = "shadow scala.meta quasiquotes"
 
   private def extractTypesFromPatten(pat: c.Tree): List[c.Type] = pat match {
     case pq"${first: c.Tree} | ..${rest: List[c.Tree]}" => first.tpe :: rest.map(_.tpe)

--- a/tqlscalametamacros/src/main/scala/scala.meta.tql/ScalametaFusionTraverserHelperMacros.scala
+++ b/tqlscalametamacros/src/main/scala/scala.meta.tql/ScalametaFusionTraverserHelperMacros.scala
@@ -50,7 +50,7 @@ class ScalametaFusionTraverserHelperMacros(override val c: Context)
   }
 
   private def getTagsFromTypes(tpes: Set[c.Type]): Set[c.Tree] = {
-    val tagTerm = TermName("$tag")
+    val tagTerm = TermName("internalTag")
     tpes.flatMap{_ match {
         case tpe if tpe.typeSymbol.isLeaf => Set(q"${tpe.typeSymbol.companion}.$tagTerm")
         case tpe if tpe.typeSymbol.isBranch =>

--- a/tqlscalametamacros/src/main/scala/scala.meta.tql/ScalametaTraverserHelperMacros.scala
+++ b/tqlscalametamacros/src/main/scala/scala.meta.tql/ScalametaTraverserHelperMacros.scala
@@ -47,7 +47,7 @@ class ScalametaTraverserBuilder(override val c: Context)
 
   //trick to make it work with the Name unapply.
   override def getParamsWithTypes(typ: c.Type): Option[(List[TermName], List[c.Type])] = {
-    val fields = typ.companion.typeSymbol.asLeaf.nontriviaFields
+    val fields = typ.companion.typeSymbol.asLeaf.fields
     if (!fields.isEmpty){
       Some(fields.map(x => (TermName(c.freshName), x.tpe) ).unzip)
     }

--- a/tqlscalametamacros/src/main/scala/scala.meta.tql/ScalametaTraverserHelperMacros.scala
+++ b/tqlscalametamacros/src/main/scala/scala.meta.tql/ScalametaTraverserHelperMacros.scala
@@ -20,7 +20,9 @@ class ScalametaTraverserBuilder(override val c: Context)
                     extends _root_.tql.TraverserBuilder(c)
                     with org.scalameta.adt.AdtReflection {
   val u: c.universe.type = c.universe
+  val mirror: u.Mirror = c.mirror
   import c.universe._
+  val XtensionQuasiquoteTerm = "shadow scala.meta quasiquotes"
 
   def getAllLeaves(root: Root) = root.allLeafs
 

--- a/tqlscalametamacros/src/main/scala/tools/transformerBuilder.scala
+++ b/tqlscalametamacros/src/main/scala/tools/transformerBuilder.scala
@@ -83,10 +83,10 @@ class TransformerMacros(override val c: Context) extends TraverserMacros(c) {
     *   if ((a1 eq scrut) && (a2 eq cases)) origin else Term.Match(a1, a2)
    * */
   def buildCase2[T : c.WeakTypeTag](leaf: Leaf, methodName: TermName): Option[c.Tree] = {
-    val listOfTransforms = leaf.nontriviaFields.map(makeTransformStat[T](_, methodName))
+    val listOfTransforms = leaf.fields.map(makeTransformStat[T](_, methodName))
     val listOfTransfromWithStats = listOfTransforms.filter(!_.stat.isEmpty)
     if (listOfTransfromWithStats.size > 0) {
-      val listOfParamNames = leaf.nontriviaFields.map(p => pq"${p.name} @ _")
+      val listOfParamNames = leaf.fields.map(p => pq"${p.name} @ _")
       val origin = TermName(c.freshName("origin"))
       val pat = pq"$origin @ ${leaf.sym.companion}(..$listOfParamNames)"
       val isEqual = listOfTransfromWithStats.foldLeft[c.Tree](q"true")((acc, c) => q"$acc && (${c.newName} eq ${c.oldName})")

--- a/tqlscalametamacros/src/main/scala/tools/traverserBuilder.scala
+++ b/tqlscalametamacros/src/main/scala/tools/traverserBuilder.scala
@@ -57,9 +57,9 @@ class TraverserMacros(val c: Context) extends AdtReflection {
   }
 
   def buildCase[T : c.WeakTypeTag](leaf: Leaf, methodName: TermName): Option[c.Tree] = {
-    val listOfTraverseStats = leaf.nontriviaFields.flatMap(makeTraverseStat[T](_, methodName))
+    val listOfTraverseStats = leaf.fields.flatMap(makeTraverseStat[T](_, methodName))
     if (listOfTraverseStats.size > 0) {
-      val listOfParamNames = leaf.nontriviaFields.map(p => pq"${p.name} @ _")
+      val listOfParamNames = leaf.fields.map(p => pq"${p.name} @ _")
       Some(cq"${leaf.sym.companion}(..$listOfParamNames) => ..$listOfTraverseStats")
     }
     else

--- a/tqlscalametamacros/src/main/scala/tools/traverserBuilder.scala
+++ b/tqlscalametamacros/src/main/scala/tools/traverserBuilder.scala
@@ -24,7 +24,7 @@ class TraverserMacros(val c: Context) extends AdtReflection {
     val Ttpe = implicitly[c.WeakTypeTag[T]]
     val nbLeaves = u.symbolOf[T].asRoot.allLeafs.size * 2
     val array = TermName(c.freshName("table"))
-    val tagTerm = TermName("$tag")
+    val tagTerm = TermName("internalTag")
     val assigns: List[c.Tree] = u.symbolOf[T].asRoot.allLeafs.map(x =>
       q"""
         $array(${x.sym.companion}.$tagTerm) = ${buildFuncForCase[T](x)}

--- a/tqlscalametamacros/src/main/scala/tools/traverserBuilder.scala
+++ b/tqlscalametamacros/src/main/scala/tools/traverserBuilder.scala
@@ -16,7 +16,9 @@ object TraverserBuilder {
 
 class TraverserMacros(val c: Context) extends AdtReflection {
   val u: c.universe.type = c.universe
-	import c.universe._
+  val mirror: u.Mirror = c.mirror
+  import c.universe._
+  val XtensionQuasiquoteTerm = "shadow scala.meta quasiquotes"
 
   def buildTraverseTable[T : c.WeakTypeTag]: c.Tree = {
     u.symbolOf[T].asRoot.allLeafs.foreach(_.sym.owner.info)
@@ -52,6 +54,7 @@ class TraverserMacros(val c: Context) extends AdtReflection {
     case t if t <:< weakTypeOf[T]           => Some(q"$methodName(${field.name})")
     case t if t <:< weakTypeOf[Seq[T]]      => Some(q"${field.name}.foreach($methodName(_))")
     case t if t <:< weakTypeOf[Seq[Seq[T]]] => Some(q"${field.name}.foreach(_.foreach($methodName(_)))")
+    case t if t <:< weakTypeOf[Option[Seq[T]]] => Some(q"${field.name}.foreach(_.foreach($methodName(_)))")
     case t if t <:< weakTypeOf[Option[T]]   => Some(q"${field.name}.foreach($methodName(_))")
     case _ => None
   }


### PR DESCRIPTION
TQL has been ported to the new version of Scalameta (0-1-0-SNAPSHOT).
Test have been ported to the new version as well but do not pass. Note that it was already the case with Scalameta 0.0.0-M0. A deeper look into TQL is probably required to find the reasons of the fails.
